### PR TITLE
Remove Configuration Directory Overrides

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,11 +2,3 @@
 
 - name: Include tasks for {{ ansible_os_family }}
   ansible.builtin.include_tasks: "{{ ansible_os_family | lower }}.yml"
-
-- name: Ensure configuration directory exists
-  ansible.builtin.file:
-    path: "/etc/elastiflow"
-    state: directory
-    owner: root
-    group: root
-    mode: '0755'


### PR DESCRIPTION
__CHANGES:__

This removes the task overriding the configuration directory since the installer already handles directory creation.